### PR TITLE
Normalize How to Buy sections

### DIFF
--- a/avionics/TFHT01/index.md
+++ b/avionics/TFHT01/index.md
@@ -14,9 +14,11 @@ Sensors mounted on UAVs can be used for a variety of purposes. TFHT can measure 
 
 ![TFHT01 in box](TFHT01_enclosure.jpg)
 
-## Where to get it?
+## How to Buy
 
-TFHT01 can be bought directly from us via our contact [email](https://www.thunderfly.cz/contact-us.html). The email can also be used if there are specific requirements for custom modifications or if the product will be inquired in large quantities. TFHT is also available for online purchase through the [Tindie store](https://www.tindie.com/products/thunderfly/tfht01-aerial-hygrometer-and-thermometer/).
+- Direct order — Email [sale@thunderfly.cz](mailto:sale@thunderfly.cz) for quotations, customization requests, or volume purchases handled by ThunderFly s.r.o.
+- [Purchase TFHT01 on Lectronz](https://lectronz.com/products/1064) for EU-based fulfillment.
+- [Purchase TFHT01 on Tindie](https://www.tindie.com/products/thunderfly/tfht01-aerial-hygrometer-and-thermometer/) for worldwide shipping.
 
 ## Parameters
 

--- a/avionics/TFI2CADT01/index.md
+++ b/avionics/TFI2CADT01/index.md
@@ -16,9 +16,11 @@ That is a common problem in case multiple I2C sensors with the same address (or 
 The module is based on [LTC4317](https://www.analog.com/media/en/technical-documentation/data-sheets/4317fa.pdf) I2C address translator IC.
 The module is designed and optimized for use on Pixhawk-compatible drones, especially UAVs. The design of the module is compatible with the [dronecode connectors standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf).
 
-## Where to get it?
+## How to Buy
 
-ThunderFly I2C address translator is commercially available from [ThunderFly s.r.o.](https://www.thunderfly.cz/), write an email to info@thunderfly.cz or shop at [Tindie store](https://www.tindie.com/products/thunderfly/tfi2cadt01-i2c-address-translator/).
+- Direct order — Email [sale@thunderfly.cz](mailto:sale@thunderfly.cz) for quotations, customizations, or volume pricing handled directly by ThunderFly s.r.o.
+- [Purchase TFI2CADT01 on Lectronz](https://lectronz.com/products/1063) for EU-friendly fulfillment.
+- [Purchase TFI2CADT01 on Tindie](https://www.tindie.com/products/thunderfly/tfi2cadt01-i2c-address-translator/) for worldwide availability.
 
 ## Translation function
 

--- a/avionics/TFRPM01/probe.md
+++ b/avionics/TFRPM01/probe.md
@@ -27,6 +27,12 @@ The sensor is specifically designed for simple RPM measurement with the TFRPM01 
 <img src="https://raw.githubusercontent.com/ThunderFly-aerospace/TFPROBE01/TFPROBE01A/doc/img/TFPROBE01A_sensors.jpg" width="48%" />
 </p>
 
+## How to Buy
+
+- Direct order — Email [sale@thunderfly.cz](mailto:sale@thunderfly.cz) for tailored quotations or volume orders handled by ThunderFly s.r.o.
+- [Purchase TFPROBE01 on Lectronz](https://lectronz.com/products/1065) for EU-friendly logistics.
+- [Purchase TFPROBE01 on Tindie](https://www.tindie.com/products/20377/) for worldwide shipping options.
+
 ### Magnetic Sensing
 
 The magnetic Hall-effect sensor mounted on the probe board can sense both directions of the magnetic field. The strength of the magnetic field is a decisive parameter for the probe's correct function. The magnetic flux is expected to be perpendicular to the sensor PCB surface. The detailed requirements of magnetic flux density are described in [AH3572 datasheet page 4](https://github.com/ThunderFly-aerospace/TFPROBE01/blob/TFPROBE01A/doc/datasheets/AH3572-1483253.pdf).

--- a/avionics/TFSLOT01/index.md
+++ b/avionics/TFSLOT01/index.md
@@ -20,7 +20,11 @@ nav_order: "10"
   * Customizable 3D-printed case to fit specific applications.
   * Integrated IMU to vibration diagnostics on AoA measurement.
 
-TFSLOT is commercially available from [ThunderFly s.r.o.](https://www.thunderfly.cz/), write an email to sale@thunderfly.cz or shop at [Lectronz](https://lectronz.com/products/1058) or [Tindie store](https://www.tindie.com/products/21790/).
+## How to Buy
+
+- Direct order — Email [sale@thunderfly.cz](mailto:sale@thunderfly.cz) with your requirements for quotations or tailored configurations provided by ThunderFly s.r.o.
+- [Purchase TFSLOT01 on Lectronz](https://lectronz.com/products/1058) for convenient EU logistics.
+- [Purchase TFSLOT01 on Tindie](https://www.tindie.com/products/21790/) for global delivery options.
 
 ## Technical Parameters
 

--- a/avionics/TFUSBSERIAL01/index.md
+++ b/avionics/TFUSBSERIAL01/index.md
@@ -21,9 +21,11 @@ The converter is designed to service and debug operations on UAVs. It respects t
   * The power delivered from USB is protected from excess current possibly drawn by peripheral or FMU
   * The accidental power from FMU to USB is protected by reverse diode
 
-## Where to get it?
+## How to Buy
 
-ThunderFly Serial Telemetry Interface is commercially available from [ThunderFly s.r.o.](https://www.thunderfly.cz/), write an email to sale@thunderfly.cz or shop at [Tindie store](https://www.tindie.com/products/34364/).
+- Direct order — Email [sale@thunderfly.cz](mailto:sale@thunderfly.cz) to request quotations, customization details, or volume pricing provided by ThunderFly s.r.o.
+- [Purchase TFUSBSERIAL01 on Lectronz](https://lectronz.com/products/1066) for streamlined EU fulfillment.
+- [Purchase TFUSBSERIAL01 on Tindie](https://www.tindie.com/products/34364/) for worldwide availability.
 
 
 ### Usage


### PR DESCRIPTION
## Summary
- unify the "How to Buy" guidance across avionics product pages
- standardize direct order instructions to the sale@thunderfly.cz contact
- present Lectronz and Tindie marketplace links without redundant labels

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68eb6601fd88832299d6daf9f0a79604